### PR TITLE
:+1: Make `path` of `GinChaperon` and `GinPatch` optional

### DIFF
--- a/denops/gin/command/chaperon/main.ts
+++ b/denops/gin/command/chaperon/main.ts
@@ -8,6 +8,7 @@ import {
   validateOpts,
 } from "jsr:@denops/std@^7.0.0/argument";
 import { fillCmdArgs, normCmdArgs, parseSilent } from "../../util/cmd.ts";
+import { ensurePath } from "../../util/ensure_path.ts";
 import { exec } from "./command.ts";
 
 export function main(denops: Denops): void {
@@ -46,8 +47,8 @@ async function command(
     ...builtinOpts,
   ]);
 
-  const [abspath] = parseResidue(residue);
-  await exec(denops, abspath, {
+  const [rawpath] = parseResidue(residue);
+  await exec(denops, await ensurePath(denops, rawpath), {
     worktree: opts.worktree,
     opener: opts.opener,
     noOurs: "no-ours" in opts,
@@ -60,9 +61,12 @@ async function command(
 
 function parseResidue(
   residue: string[],
-): [string] {
-  // GinChaperon [{options}] {path}
+): [string | undefined] {
   switch (residue.length) {
+    // GinChaperon [{options}]
+    case 0:
+      return [undefined];
+    // GinChaperon [{options}] {path}
     case 1:
       return [residue[0]];
     default:

--- a/denops/gin/command/patch/main.ts
+++ b/denops/gin/command/patch/main.ts
@@ -8,6 +8,7 @@ import {
   validateOpts,
 } from "jsr:@denops/std@^7.0.0/argument";
 import { fillCmdArgs, normCmdArgs, parseSilent } from "../../util/cmd.ts";
+import { ensurePath } from "../../util/ensure_path.ts";
 import { exec } from "./command.ts";
 
 export function main(denops: Denops): void {
@@ -46,8 +47,8 @@ async function command(
     ...builtinOpts,
   ]);
 
-  const [abspath] = parseResidue(residue);
-  await exec(denops, abspath, {
+  const [rawpath] = parseResidue(residue);
+  await exec(denops, await ensurePath(denops, rawpath), {
     worktree: opts.worktree,
     noHead: "no-head" in opts,
     noWorktree: "no-worktree" in opts,
@@ -60,9 +61,12 @@ async function command(
 
 function parseResidue(
   residue: string[],
-): [string] {
-  // GinPatch [{options}] {path}
+): [string | undefined] {
   switch (residue.length) {
+    // GinPatch [{options}]
+    case 0:
+      return [undefined];
+    // GinPatch [{options}] {path}
     case 1:
       return [residue[0]];
     default:

--- a/denops/gin/util/ensure_path.ts
+++ b/denops/gin/util/ensure_path.ts
@@ -1,0 +1,21 @@
+import type { Denops } from "jsr:@denops/std@^7.0.0";
+import * as fn from "jsr:@denops/std@^7.0.0/function";
+
+/**
+ * Ensure the path is absolute.
+ *
+ * It returns the absolute path of the given path. If the path is not given, it
+ * returns the absolute path of the current buffer.
+ *
+ * @param denops Denops instance.
+ * @param path Path to ensure.
+ * @returns Absolute path.
+ */
+export async function ensurePath(
+  denops: Denops,
+  path?: string,
+): Promise<string> {
+  const bufname = await fn.expand(denops, path ?? "%") as string;
+  const abspath = await fn.fnamemodify(denops, bufname, ":p");
+  return abspath;
+}

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -217,9 +217,10 @@ COMMANDS					*gin-commands*
 	directory. Commands call |cd|, |lcd|, and |tcd| respectively.
 	
 							*:GinChaperon*
-:GinChaperon[!] [++{option}...] {path}
+:GinChaperon[!] [++{option}...] [{path}]
 	Open three main buffers (THEIRS, WORKTREE, and OURS) and three
-	supplemental buffers to solve conflicts on {path}.
+	supplemental buffers to solve conflicts on {path}. If no {path} is
+	specified, the default value is the current buffer.
 
 	The following options are valid as {++option}:
 

--- a/doc/gin.txt
+++ b/doc/gin.txt
@@ -344,9 +344,10 @@ COMMANDS					*gin-commands*
 	Use a bang (!) to forcibly open a buffer.
 
 							*:GinPatch*
-:GinPatch[!] [{++option}...] {path}
+:GinPatch[!] [{++option}...] [{path}]
 	Open three buffers (HEAD, INDEX, and WORKTREE) to patch changes of
-	{path}.
+	{path}. If no {path} is specified, the default value is the current
+	buffer.
 
 	The following options are valid as {++option}:
 


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a path validation utility to ensure paths used in commands are absolute.
  - Enhanced command handling to accommodate optional path parameters.

- **Bug Fixes**
  - Updated functions to correctly handle scenarios where no path is provided, reducing errors related to undefined paths.

- **Documentation**
  - Clarified command syntax in documentation, indicating that the path parameter is now optional and defaults to the current buffer if omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->