### PR TITLE
Do NOT expand `path` to support special characters in path.

### DIFF
--- a/denops/gin/util/ensure_path.ts
+++ b/denops/gin/util/ensure_path.ts
@@ -15,7 +15,7 @@ export async function ensurePath(
   denops: Denops,
   path?: string,
 ): Promise<string> {
-  const bufname = await fn.expand(denops, path ?? "%") as string;
-  const abspath = await fn.fnamemodify(denops, bufname, ":p");
+  const expr = path ?? await fn.bufname(denops);
+  const abspath = await fn.fnamemodify(denops, expr, ":p");
   return abspath;
 }


### PR DESCRIPTION
For example, React Router v7 with file-based routing use `$paramName` in path and that is not environment variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved how the current buffer path is determined when no path is provided, ensuring more accurate path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->