### PR TITLE
Add `git worktree` support actions and `:x` variants to `rebase` actions

### DIFF
--- a/denops/gin/action/branch_delete.ts
+++ b/denops/gin/action/branch_delete.ts
@@ -4,7 +4,7 @@ import { define, GatherCandidates, Range } from "./core.ts";
 
 export type Candidate =
   | { kind: "remote"; branch: string; remote: string }
-  | { kind?: "alias" | "local"; branch: string };
+  | { kind?: "alias" | "local"; branch: string; worktree?: string };
 
 export async function init(
   denops: Denops,
@@ -50,11 +50,19 @@ async function doDelete(
         ]);
         break;
       default:
-        await denops.dispatch("gin", "command", "", [
-          "branch",
-          force ? "-D" : "-d",
-          x.branch,
-        ]);
+        if (x.worktree) {
+          await denops.dispatch("gin", "command", "", [
+            "worktree",
+            "remove",
+            x.worktree,
+          ]);
+        } else {
+          await denops.dispatch("gin", "command", "", [
+            "branch",
+            force ? "-D" : "-d",
+            x.branch,
+          ]);
+        }
         break;
     }
   }

--- a/denops/gin/command/branch/edit.ts
+++ b/denops/gin/command/branch/edit.ts
@@ -19,6 +19,7 @@ import { init as initActionMerge } from "../../action/merge.ts";
 import { init as initActionRebase } from "../../action/rebase.ts";
 import { init as initActionSwitch } from "../../action/switch.ts";
 import { init as initActionYank } from "../../action/yank.ts";
+import { init as initActionWorktreeNew } from "../../action/worktree_new.ts";
 import { Branch, parse as parseBranch } from "./parser.ts";
 
 export async function edit(
@@ -71,6 +72,7 @@ export async function exec(
       await initActionBranchDelete(denops, bufnr, gatherCandidates);
       await initActionBranchMove(denops, bufnr, gatherCandidates);
       await initActionBranchNew(denops, bufnr, gatherCandidates);
+      await initActionWorktreeNew(denops, bufnr, gatherCandidates);
       await initActionBrowse(denops, bufnr, async (denops, bufnr, range) => {
         const xs = await gatherCandidates(denops, bufnr, range);
         return xs.map((b) => ({ commit: b.target, ...b }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to create new Git worktrees, including forced and orphan worktree creation, through new commands.
  - Introduced post-rebase command execution, allowing users to run custom commands immediately after rebase operations.
- **Enhancements**
  - Improved branch deletion and move actions to handle branches associated with worktrees, offering more flexible management options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->